### PR TITLE
Drop Publish from list of services using school autocomplete

### DIFF
--- a/app/views/design-system/patterns/select-a-school/index.njk
+++ b/app/views/design-system/patterns/select-a-school/index.njk
@@ -90,7 +90,6 @@
 <li><a href="https://schools-financial-benchmarking.service.gov.uk" target="_blank">Schools financial benchmarking</a></li>
 <li><a href="https://www.find-school-performance-data.service.gov.uk" target="_blank">Find school and college performance data in England</a></li>
 <li><a href="https://www.register-trainee-teachers.service.gov.uk" target="_blank">Register trainee teachers</a></li>
-<li><a href="https://www.publish-teacher-training-courses.service.gov.uk/sign-in" target="_blank">Publish teacher training courses</a></li>
 <li><a href="https://www.get-help-buying-for-schools.service.gov.uk" target="_blank">Get help buying for schools</a></li>
 </ul>
 


### PR DESCRIPTION
Publish teacher training courses doesn't currently have a "select school" autocomplete.

(I made a mistake on this as it was previously used in some prototypes for Publish)

Thanks to @simonwhatley for pointing this out.