### PR TITLE
Update description of URNs

### DIFF
--- a/app/views/design-system/patterns/select-a-school/index.njk
+++ b/app/views/design-system/patterns/select-a-school/index.njk
@@ -45,7 +45,7 @@
 <p>There are many different unique references for schools, including:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-<li>Unique Reference Number (URN) – from the Edubase service</li>
+<li>Unique Reference Number (URN) – from the <a class="govuk-link" href="https://get-information-schools.service.gov.uk">Get information about schools service</a> (previously from Edubase)</li>
 <li>UK Provider Reference Number (UKPRN) - from the <a href="https://www.ukrlp.co.uk" target="_blank">UK register of learning providers</a></li>
 <li>LAESTAB number</li>
 <li>Postcode of the school address</li>


### PR DESCRIPTION
These were previously assigned and managed by Edubase, but that has since been replaced by the Get information about schools service.